### PR TITLE
feat(tutor): 沉淀客观题答题循环 SOP，脱敏脚本与 topic map

### DIFF
--- a/.claude/agents/senior-architect-pass-coach.md
+++ b/.claude/agents/senior-architect-pass-coach.md
@@ -20,7 +20,7 @@ You are the repository's pass-first Senior Software Architect exam coach.
 
 ## 每次开始前
 
-1. 读取 `tutor/PROGRESS_PROTOCOL.md`、`tutor/curriculum.json` 和相关保命卡。
+1. 读取 `tutor/PROGRESS_PROTOCOL.md`、`tutor/curriculum.json`、[`tutor/quiz-loop-sop.md`](../../tutor/quiz-loop-sop.md)（客观题一轮的运行时管道）、[`tutor/topic-map.md`](../../tutor/topic-map.md)（考点↔资源↔facet 表，脚本自动生成）和相关保命卡。
 2. 检查 `.study/`：
    - 不存在时，明确说明目前没有证据可判断进度。最多先收集考试日期、每日可投入分钟数、既往模考/强弱项三类信息；随后初始化私人状态。
    - 已存在时，读取状态、答题事件、到期复习和三科最近证据，准确续接。若存在 `.study/postmortems.jsonl`，同时读取最近一次尚未处理的机考错因补充，并按 `mock_id` 与 `attempts.jsonl` 中同场逐题事件关联。

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,9 +4,10 @@
 
 1. 先完整读取 [`.claude/agents/senior-architect-pass-coach.md`](./.claude/agents/senior-architect-pass-coach.md)，将其作为本仓库唯一的教师行为规范。
 2. 再读取 [`tutor/PROGRESS_PROTOCOL.md`](./tutor/PROGRESS_PROTOCOL.md) 和 [`tutor/curriculum.json`](./tutor/curriculum.json)。
-3. 使用 `scripts/tutor.py` 维护 `.study/` 中的私人学习状态；若状态不存在，明确说“不知道当前进度”，先建档和诊断，禁止编造。
-4. 个人档案、答题记录、错题、论文项目素材和会话记录默认只能写入根目录 `.study/`；只有用户明确指定时才可写入仓库外的私人目录。不得写入公共题库、范文、Issue 或其他受 Git 跟踪文件；不得使用 `git add -f .study`。
-5. 给考生出题时，作答前只展示题干和选项，不展示答案标记、解析或文件中加粗的正确项。
+3. 若本轮任务是"出题→作答→判分→记档"的客观题循环，另读 [`tutor/quiz-loop-sop.md`](./tutor/quiz-loop-sop.md) 与 [`tutor/topic-map.md`](./tutor/topic-map.md)，并用 [`scripts/sanitize_bank.py`](./scripts/sanitize_bank.py) 剥除 `exam-bank/` 里的答案标记后再呈现给考生。
+4. 使用 `scripts/tutor.py` 维护 `.study/` 中的私人学习状态；若状态不存在，明确说“不知道当前进度”，先建档和诊断，禁止编造。
+5. 个人档案、答题记录、错题、论文项目素材和会话记录默认只能写入根目录 `.study/`；只有用户明确指定时才可写入仓库外的私人目录。不得写入公共题库、范文、Issue 或其他受 Git 跟踪文件；不得使用 `git add -f .study`。
+6. 给考生出题时，作答前只展示题干和选项，不展示答案标记、解析或文件中加粗的正确项。
 
 当用户是在维护仓库代码或资料，而不是备考时，按普通仓库协作方式处理，不强制进入私教模式。
 

--- a/scripts/gen_topic_map.py
+++ b/scripts/gen_topic_map.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python3
+"""Generate ``tutor/topic-map.md`` from ``tutor/curriculum.json``.
+
+The topic map is a reference the coach reads before recommending questions:
+
+* which stable topic ID maps to which exam-bank / cheatsheet files, and
+* which aggregate topics need ``--facet`` when calling ``tutor.py record``.
+
+Keeping the map generated (rather than hand-written) prevents drift the next
+time ``curriculum.json`` gains a facet or a new topic.
+
+Usage::
+
+    python3 scripts/gen_topic_map.py            # rewrite tutor/topic-map.md
+    python3 scripts/gen_topic_map.py --check    # exit 1 if out of date (for CI)
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Iterable
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+CURRICULUM = REPO_ROOT / "tutor" / "curriculum.json"
+OUTPUT = REPO_ROOT / "tutor" / "topic-map.md"
+
+
+def _resource_kind(path: str) -> str:
+    if path.startswith("exam-bank/"):
+        return "exam-bank"
+    if path.startswith("cheatsheets/"):
+        return "cheatsheet"
+    if path.startswith("notes/"):
+        return "notes"
+    if path.startswith("past-papers/"):
+        return "past-papers"
+    if path.startswith("knowledge-index/"):
+        return "knowledge-index"
+    return "other"
+
+
+def _has_bank_items(resources: Iterable[str]) -> bool:
+    return any(r.startswith("exam-bank/") for r in resources)
+
+
+def render(curriculum: dict) -> str:
+    topics = curriculum.get("topics", [])
+    aggregate = [t for t in topics if t.get("facets")]
+
+    lines: list[str] = []
+    lines.append("# Topic Map（由脚本生成，请勿手改）")
+    lines.append("")
+    lines.append(
+        "> 由 `python3 scripts/gen_topic_map.py` 从 "
+        "[`tutor/curriculum.json`](./curriculum.json) 生成。"
+        "若要修改，请改 curriculum.json 后重跑该脚本。"
+    )
+    lines.append("")
+    lines.append("## 1. 聚合考点（`record --facet` 必填）")
+    lines.append("")
+    if aggregate:
+        lines.append("| Topic ID | 名称 | Facets |")
+        lines.append("|---|---|---|")
+        for t in aggregate:
+            facets = " / ".join(f"`{f}`" for f in t["facets"])
+            lines.append(f"| `{t['id']}` | {t['name']} | {facets} |")
+    else:
+        lines.append("_当前无聚合考点。_")
+    lines.append("")
+
+    lines.append("## 2. 所有考点 → 资源映射")
+    lines.append("")
+    lines.append("| Topic ID | 名称 | 科目 | 频次 | 时长(分钟) | 有 exam-bank 题 | 主要资源 |")
+    lines.append("|---|---|---|---|---|---|---|")
+    for t in topics:
+        subjects = "/".join(t.get("subjects", []))
+        freq = t.get("frequency_count", "—")
+        est = t.get("estimated_minutes", "—")
+        resources = t.get("resources", []) or []
+        has_bank = "✅" if _has_bank_items(resources) else "⚠️ 无"
+        # Show up to 3 resources for readability
+        shown = ", ".join(f"`{r}`" for r in resources[:3])
+        if len(resources) > 3:
+            shown += f" (+{len(resources) - 3})"
+        lines.append(
+            f"| `{t['id']}` | {t['name']} | {subjects} | {freq} | {est} | {has_bank} | {shown} |"
+        )
+    lines.append("")
+
+    # Group orphaned topics (no exam-bank items) — these need self-authored
+    # questions and must be tagged with ``--source-type self_authored``.
+    no_bank = [t for t in topics if not _has_bank_items(t.get("resources", []) or [])]
+    if no_bank:
+        lines.append("## 3. 无 exam-bank 题的考点（自编题时 `--source-type self_authored`）")
+        lines.append("")
+        for t in no_bank:
+            lines.append(f"- `{t['id']}` — {t['name']}")
+        lines.append("")
+
+    lines.append("## 4. exam-bank 文件 → topic 反查")
+    lines.append("")
+    # Build reverse index for the exam-bank/ resources
+    reverse: dict[str, list[str]] = {}
+    for t in topics:
+        for r in t.get("resources", []) or []:
+            if r.startswith("exam-bank/"):
+                reverse.setdefault(r, []).append(t["id"])
+    for path in sorted(reverse):
+        topics_str = ", ".join(f"`{tid}`" for tid in sorted(reverse[path]))
+        lines.append(f"- `{path}` → {topics_str}")
+    lines.append("")
+
+    return "\n".join(lines) + "\n"
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="exit 1 if the generated map differs from the file on disk",
+    )
+    args = parser.parse_args(argv)
+
+    curriculum = json.loads(CURRICULUM.read_text(encoding="utf-8"))
+    rendered = render(curriculum)
+
+    if args.check:
+        current = OUTPUT.read_text(encoding="utf-8") if OUTPUT.exists() else ""
+        if current != rendered:
+            print(
+                f"error: {OUTPUT.relative_to(REPO_ROOT)} is out of date; "
+                "run `python3 scripts/gen_topic_map.py`",
+                file=sys.stderr,
+            )
+            return 1
+        return 0
+
+    OUTPUT.write_text(rendered, encoding="utf-8")
+    print(f"wrote {OUTPUT.relative_to(REPO_ROOT)} ({len(rendered)} bytes)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/scripts/sanitize_bank.py
+++ b/scripts/sanitize_bank.py
@@ -1,0 +1,224 @@
+#!/usr/bin/env python3
+"""
+Sanitize exam-bank blocks for coach-driven quiz sessions.
+
+Reads an exam-bank markdown file, extracts the question blocks whose header
+starts with ``### N.`` for the given N values, strips inline answer markers
+(``✅``, bold correct-option markers, ``**答案**:`` / ``**答案**：`` lines, and
+the trailing ``**解析**:`` / ``**解析**：`` section), and prints a JSON list
+to stdout. Each item has::
+
+    {
+        "id": "exam-bank/<file>.md#<N>",
+        "stem": "<question stem, single line>",
+        "options": [{"label": "A", "text": "..."}, ...],
+        "correct": ["B"],   # coach-only, DO NOT echo to the learner
+        "explanation": "..." # coach-only, only for post-answer feedback
+    }
+
+Usage::
+
+    python3 scripts/sanitize_bank.py <path-to-exam-bank.md> <N> [<N> ...]
+
+Example::
+
+    python3 scripts/sanitize_bank.py exam-bank/07-software-engineering.md 1 4 6
+
+Supported option-line formats (learners will never see the raw form):
+
+  * ``A. text`` / ``B. text`` / ``C. text`` / ``D. text``  (bare)
+  * ``- A. text``                                           (bulleted)
+  * ``✅ **D. text**``                                       (correct marker)
+  * ``- **B. text**``                                       (correct via bold)
+  * option text may contain inline ``**bold**`` for emphasis
+  * an explicit ``**答案**: X`` / ``**答案**：X`` line, when present, wins over
+    ``✅`` heuristics.
+"""
+from __future__ import annotations
+
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Dict, List
+
+
+BLOCK_HEADER = re.compile(r"^###\s+(\d+)[.\s]", re.MULTILINE)
+# Match option lines in all supported shapes:
+#   "A. text", "- A. text", "* A. text", "**A. text**"
+# Correct-answer prefixes (``✅`` and outer ``**``) are stripped from the
+# probe string before matching so the same regex handles both plain and marked
+# lines.
+OPTION_LINE = re.compile(
+    r"""^\s*
+        (?:[-*]\s+)?           # optional bullet marker
+        ([A-Z])                # 1: option letter
+        [\.\)、]                # separator: dot, right paren, or Chinese enum comma
+        \s*
+        (.+?)                  # 2: option text (non-greedy)
+        \s*$""",
+    re.VERBOSE,
+)
+BOLD_MARK = re.compile(r"\*\*(.+?)\*\*")
+ANSWER_LINE = re.compile(
+    r"^\s*\*\*\s*答\s*案\s*\*\*\s*[:：]\s*(.+?)\s*$", re.MULTILINE
+)
+EXPLAIN_LINE = re.compile(
+    r"^\s*\*\*\s*解\s*析\s*\*\*\s*[:：]\s*(.*)$", re.MULTILINE
+)
+SEPARATOR_LINE = re.compile(r"^\s*-{3,}\s*$")
+CHECK_MARK = "✅"
+
+
+def split_blocks(text: str) -> Dict[str, str]:
+    """Return a mapping of question number -> raw block text (with header)."""
+    blocks: Dict[str, str] = {}
+    positions = [(m.start(), m.group(1)) for m in BLOCK_HEADER.finditer(text)]
+    for i, (start, num) in enumerate(positions):
+        end = positions[i + 1][0] if i + 1 < len(positions) else len(text)
+        blocks[num] = text[start:end]
+    return blocks
+
+
+def _clean_text(value: str) -> str:
+    """Remove residual markers and collapse whitespace."""
+    value = value.replace(CHECK_MARK, "")
+    value = BOLD_MARK.sub(r"\1", value)
+    value = re.sub(r"\s+", " ", value)
+    return value.strip()
+
+
+def _probe_option(stripped: str):
+    """Return (letter, body, is_marked_correct) or None if not an option line.
+
+    Peels off ``✅`` and outer ``**...**`` wrappers (both of which signal the
+    correct answer in exam-bank markdown) before attempting to match the
+    option pattern. ``is_marked_correct`` is True when any such marker was
+    present.
+    """
+    marked = False
+    probe = stripped
+
+    # Peel ✅ prefix (may be followed by whitespace or **)
+    if probe.startswith(CHECK_MARK):
+        marked = True
+        probe = probe[len(CHECK_MARK):].lstrip()
+
+    # Peel a leading bullet marker so we can inspect the payload
+    bullet = ""
+    if probe.startswith(("- ", "* ")):
+        bullet = probe[:2]
+        probe = probe[2:].lstrip()
+
+    # Peel outer ** ... ** wrapping the entire option payload
+    if probe.startswith("**") and probe.endswith("**") and len(probe) >= 4:
+        marked = True
+        probe = probe[2:-2].strip()
+
+    # Restore bullet so OPTION_LINE can still recognise the shape uniformly
+    probe = f"{bullet}{probe}" if bullet else probe
+
+    m = OPTION_LINE.match(probe)
+    if not m:
+        return None
+    return m.group(1), m.group(2).strip(), marked
+
+
+def parse_block(raw: str) -> Dict:
+    """Parse one raw block into a structured item."""
+    lines = raw.splitlines()
+    header = lines[0] if lines else ""
+    header_body = re.sub(r"^###\s+\d+[.\s]\s*", "", header).strip()
+    header_body = _clean_text(header_body)
+
+    stem_parts: List[str] = [header_body] if header_body else []
+    options: List[Dict[str, str]] = []
+    correct_from_marker: List[str] = []
+    answer_from_line: List[str] = []
+    explanation_lines: List[str] = []
+    in_explanation = False
+    seen_first_option = False
+
+    for line in lines[1:]:
+        if SEPARATOR_LINE.match(line):
+            in_explanation = False
+            continue
+
+        m_ans = ANSWER_LINE.match(line)
+        if m_ans:
+            answer_from_line = re.findall(r"[A-Z]", m_ans.group(1))
+            in_explanation = False
+            continue
+
+        m_exp = EXPLAIN_LINE.match(line)
+        if m_exp:
+            in_explanation = True
+            first = m_exp.group(1).strip()
+            if first:
+                explanation_lines.append(first)
+            continue
+
+        if in_explanation:
+            if line.strip():
+                explanation_lines.append(line.strip())
+            continue
+
+        stripped = line.strip()
+        if not stripped:
+            continue
+
+        probed = _probe_option(stripped)
+        if probed is not None:
+            label, body, is_marked = probed
+            if is_marked:
+                correct_from_marker.append(label)
+            options.append({"label": label, "text": _clean_text(body)})
+            seen_first_option = True
+            continue
+
+        # Not an option line. Before the first option → stem continuation.
+        # After options started → likely stray/answer hint; drop silently.
+        if not seen_first_option:
+            stem_parts.append(_clean_text(stripped))
+
+    correct = answer_from_line or correct_from_marker
+    return {
+        "stem": " ".join(p for p in stem_parts if p).strip(),
+        "options": options,
+        "correct": sorted(set(correct)),
+        "explanation": " ".join(explanation_lines).strip() or None,
+    }
+
+
+def main(argv: List[str]) -> int:
+    if len(argv) < 3:
+        print(__doc__, file=sys.stderr)
+        return 2
+    path = Path(argv[1])
+    if not path.exists():
+        print(f"error: file not found: {path}", file=sys.stderr)
+        return 2
+    numbers = [n.strip() for n in argv[2:] if n.strip()]
+    text = path.read_text(encoding="utf-8")
+    blocks = split_blocks(text)
+    items: List[Dict] = []
+    missing: List[str] = []
+    for n in numbers:
+        raw = blocks.get(n)
+        if raw is None:
+            missing.append(n)
+            continue
+        item = parse_block(raw)
+        item["id"] = f"{path.as_posix()}#{n}"
+        items.append(item)
+    if missing:
+        print(
+            f"warning: missing question numbers in {path}: {', '.join(missing)}",
+            file=sys.stderr,
+        )
+    print(json.dumps(items, ensure_ascii=False, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/tests/test_sanitize_bank.py
+++ b/tests/test_sanitize_bank.py
@@ -1,0 +1,164 @@
+"""Tests for :mod:`scripts.sanitize_bank`.
+
+These tests pin the answer-stripping contract that the pass-first coach
+depends on: learners must never see ``✅`` markers, bold correct-option
+wrappers, ``**答案**`` lines, or ``**解析**`` sections in the questions we
+present. If any of those leaks back into ``options[].text`` or ``stem``,
+we've regressed.
+"""
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCRIPT_PATH = REPO_ROOT / "scripts" / "sanitize_bank.py"
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("sanitize_bank", SCRIPT_PATH)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+sanitize_bank = _load_module()
+
+
+class SanitizeBankRealBankTests(unittest.TestCase):
+    """Run the sanitizer against a real exam-bank file shipped with the repo."""
+
+    def test_software_engineering_first_three_questions(self) -> None:
+        target = REPO_ROOT / "exam-bank" / "07-software-engineering.md"
+        self.assertTrue(target.exists(), "sample exam-bank file must exist")
+        text = target.read_text(encoding="utf-8")
+        blocks = sanitize_bank.split_blocks(text)
+        for num in ("1", "4", "6"):
+            with self.subTest(question=num):
+                self.assertIn(num, blocks, f"question {num} missing from bank")
+                item = sanitize_bank.parse_block(blocks[num])
+                # Stem must be non-empty and free of any answer markers.
+                self.assertTrue(item["stem"])
+                self.assertNotIn("✅", item["stem"])
+                self.assertNotIn("答案", item["stem"])
+                self.assertNotIn("解析", item["stem"])
+                # Exactly four options, labels A-D, no marker leakage.
+                self.assertEqual(len(item["options"]), 4)
+                labels = [opt["label"] for opt in item["options"]]
+                self.assertEqual(labels, ["A", "B", "C", "D"])
+                for opt in item["options"]:
+                    self.assertNotIn("✅", opt["text"])
+                    self.assertFalse(
+                        opt["text"].startswith("**"),
+                        f"option text leaks bold wrapper: {opt}",
+                    )
+                    self.assertFalse(
+                        opt["text"].endswith("**"),
+                        f"option text leaks bold wrapper: {opt}",
+                    )
+                # A correct answer must be detected exactly once.
+                self.assertEqual(len(item["correct"]), 1)
+                self.assertIn(item["correct"][0], set(labels))
+
+
+class SanitizeBankSyntheticTests(unittest.TestCase):
+    """Cover formatting variants that have burned us in real coaching sessions."""
+
+    def test_inline_check_before_bold_wrapped_option(self) -> None:
+        sample = (
+            "### 1. Which is correct?\n\n"
+            "A. wrong\n\n"
+            "B. wrong\n\n"
+            "C. wrong\n\n"
+            "✅ **D. right answer**\n\n"
+            "**答案**：D\n"
+            "**解析**：because.\n---\n"
+        )
+        item = sanitize_bank.parse_block(sample)
+        self.assertEqual(item["correct"], ["D"])
+        self.assertEqual(len(item["options"]), 4)
+        self.assertEqual(item["options"][3]["text"], "right answer")
+        self.assertNotIn("答案", item["stem"])
+
+    def test_bulleted_option_with_bold_marker(self) -> None:
+        sample = (
+            "### 2. RUP 顺序是：\n"
+            "- A. 启动 → 构建 → 精化 → 移交\n"
+            "- **B. 初始 → 精化 → 构建 → 移交**\n"
+            "- C. 需求 → 设计 → 实现 → 测试\n"
+            "- D. 计划 → 分析 → 部署 → 维护\n"
+        )
+        item = sanitize_bank.parse_block(sample)
+        self.assertEqual(item["correct"], ["B"])
+        self.assertEqual(
+            [opt["text"] for opt in item["options"]],
+            [
+                "启动 → 构建 → 精化 → 移交",
+                "初始 → 精化 → 构建 → 移交",
+                "需求 → 设计 → 实现 → 测试",
+                "计划 → 分析 → 部署 → 维护",
+            ],
+        )
+
+    def test_explicit_answer_line_beats_marker(self) -> None:
+        # Coach convention: an explicit **答案** always wins.
+        sample = (
+            "### 3. stem\n"
+            "A. a\n"
+            "✅ B. b\n"
+            "C. c\n"
+            "D. d\n"
+            "**答案**: C\n"
+            "**解析**: coach explanation.\n"
+        )
+        item = sanitize_bank.parse_block(sample)
+        self.assertEqual(item["correct"], ["C"])
+        self.assertEqual(item["explanation"], "coach explanation.")
+
+    def test_full_width_colon_variants(self) -> None:
+        # Real bank uses ``**答案**：`` with a full-width colon.
+        sample = "### 4. stem\nA. a\nB. b\nC. c\nD. d\n**答案**：A\n**解析**：ok\n"
+        item = sanitize_bank.parse_block(sample)
+        self.assertEqual(item["correct"], ["A"])
+        self.assertEqual(item["explanation"], "ok")
+
+
+class SanitizeBankCliTests(unittest.TestCase):
+    """The CLI path is what the coach actually invokes."""
+
+    def test_cli_prints_missing_question_warning(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            sample = Path(tmp) / "bank.md"
+            sample.write_text(
+                "### 1. stem\nA. a\nB. b\nC. c\nD. d\n**答案**: A\n",
+                encoding="utf-8",
+            )
+            result = subprocess.run(
+                [sys.executable, str(SCRIPT_PATH), str(sample), "1", "99"],
+                capture_output=True,
+                text=True,
+                check=True,
+            )
+            payload = json.loads(result.stdout)
+            self.assertEqual(len(payload), 1)
+            self.assertEqual(payload[0]["correct"], ["A"])
+            self.assertIn("99", result.stderr)
+
+    def test_cli_missing_file_errors(self) -> None:
+        result = subprocess.run(
+            [sys.executable, str(SCRIPT_PATH), "no-such-file.md", "1"],
+            capture_output=True,
+            text=True,
+        )
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("file not found", result.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tutor/README.md
+++ b/tutor/README.md
@@ -52,6 +52,16 @@ python3 scripts/serve.py
 
 整个 `.study/` 已被 Git 忽略。不要使用 `git add -f .study`，不要把真实公司、客户、系统或个人信息写入公共仓库、Issue 或 PR。
 
+## 教师 & 运行时文档
+
+- [`.claude/agents/senior-architect-pass-coach.md`](../.claude/agents/senior-architect-pass-coach.md) — 教师人格与决策规则（诊断 / 案例 / 论文全流程）
+- [`PROGRESS_PROTOCOL.md`](./PROGRESS_PROTOCOL.md) — 记档规则、证据分级、隐私边界
+- [`quiz-loop-sop.md`](./quiz-loop-sop.md) — 客观题一轮"出题→作答→判分→记档"的运行时管道
+- [`topic-map.md`](./topic-map.md) — 考点↔资源↔facet 映射表（脚本自动生成，请勿手改）
+- [`../scripts/tutor.py`](../scripts/tutor.py) — 私人进度 CLI（`init` / `status` / `recommend` / `record` / `doctor`）
+- [`../scripts/sanitize_bank.py`](../scripts/sanitize_bank.py) — exam-bank 答案脱敏器
+- [`../scripts/gen_topic_map.py`](../scripts/gen_topic_map.py) — 由 `curriculum.json` 重新生成 `topic-map.md`
+
 ## 常用说法
 
 | 你说 | 私教会做 |

--- a/tutor/quiz-loop-sop.md
+++ b/tutor/quiz-loop-sop.md
@@ -1,0 +1,204 @@
+# 答题循环 SOP · Quiz Loop Runtime
+
+> 出题 / 作答 / 判分 / 记档 / 反馈 / 换科 的运行时管道。
+> 与 [`tutor/PROGRESS_PROTOCOL.md`](./PROGRESS_PROTOCOL.md)（记档规则）和
+> [`.claude/agents/senior-architect-pass-coach.md`](../.claude/agents/senior-architect-pass-coach.md)（教师人格）
+> 配合使用。本文只讲**怎么把一轮客观题跑完并落盘**，不覆盖案例/论文的完整训练循环
+> （那部分在 coach 人格里）。
+
+## 何时用
+
+- 用户说：复习 / 学习 / 保分 / 过线 / 私教 / 继续答题 / 换科 / 出题 / 出下一题 / 再来一组
+- 用户已答完一屏、等你判分和下一屏
+- 用户明确要求"选择器点选式"作答
+
+**不用**这套流程的场景：
+- 只讲教材、不考核（passive lecture）
+- 案例题、论文题的完整训练（用 coach 人格里的对应流程）
+- `.study/` 损坏或缺失 → 先按 coach 人格里的建档步骤走
+
+## 前置检查
+
+进入循环前必须过：
+- CWD 在本仓库根，`python3 scripts/tutor.py --help` 正常
+- 已读 [`PROGRESS_PROTOCOL.md`](./PROGRESS_PROTOCOL.md) 与
+  [`.claude/agents/senior-architect-pass-coach.md`](../.claude/agents/senior-architect-pass-coach.md)
+- `.study/` 存在（若无，先按 coach 人格建档）
+- 已跑过 `python3 scripts/tutor.py doctor`，三项 PASS
+
+## Step 1 · 引擎推荐下一考点
+
+```bash
+python3 scripts/tutor.py recommend --limit 6
+# 若要切换科目：
+python3 scripts/tutor.py recommend --subject case --limit 6
+python3 scripts/tutor.py recommend --subject essay --limit 6
+```
+
+从输出取**优先级最高、且有 exam-bank 题**的考点。
+"有没有 exam-bank 题"用
+[`tutor/topic-map.md`](./topic-map.md)（脚本自动生成）查。
+
+若 recommend 头部考点在 topic-map 的"无 exam-bank 题"清单里（`C01–C04`、
+`P01–P06` 等），需要自编题，并在 record 时打 `--source-type self_authored`。
+
+## Step 2 · 题目脱敏
+
+exam-bank 的题目块结构：
+
+```
+### N. 题干（可能含 **加粗关键词**）
+
+A. 选项文本
+
+B. 选项文本
+
+C. 选项文本
+
+✅ **D. 正确选项文本**
+
+**答案**：D
+**解析**：……
+---
+```
+
+`✅` / 整行 `**...**` / `**答案**：X` / `**解析**：` 都是内联的。**绝对不要直接把这段贴给用户**。
+
+用 `scripts/sanitize_bank.py` 剥离：
+
+```bash
+python3 scripts/sanitize_bank.py exam-bank/07-software-engineering.md 1 4 6
+```
+
+输出是 JSON 数组，每项含 `stem` / `options[]` / `correct` / `explanation`。
+`correct` 与 `explanation` **只**用于判分和作答后反馈，**不**在作答前回显。
+
+## Step 3 · AskUserQuestion 点选出题
+
+学员偏好点选。`AskUserQuestion` 的正确姿势：
+
+- 每次调用 ≤ 4 题（工具上限）
+- `label` 只放选项字母：`"A"` / `"B"` / `"C"` / `"D"`（`label` 有 12 字符限制）
+- `question` 放完整题干（含"下列错误的是"这类否定词）
+- `options[].description` 放该选项的**完整文本**
+- `header` 放很短的题目标签，如 `"Q1 瀑布模型"`
+
+11 题拆成 4+4+3，最后一屏可以补一道"整体把握度"自评问题
+（`稳 / 不确定 / 蒙`）。
+
+**反面示例（不要这样写）**：
+- `label: "A. 严格按顺序..."` ❌（超长 + 违反 12 字符限制）
+- `label: "瀑布顺序描述"` ❌（label 应是选项标识，不是题干）
+- 把 `correct` 或 `✅` 塞进 `description` ❌（泄题）
+
+## Step 4 · 逐题 record 入档
+
+每答完一屏，立即按题逐条 record：
+
+```bash
+python3 scripts/tutor.py record \
+  --attempt-id a-YYYYMMDD-dNN \
+  --topic <K编号.XXX> \
+  --item-id 'exam-bank/<file>.md#<N>' \
+  --skill recognition \
+  --subject comprehensive \
+  --mode diagnostic \
+  --score 0|1 --max-score 1 \
+  --confidence sure|unsure|guessed \
+  --source-type past_paper|self_authored
+```
+
+### 聚合考点必须传 `--facet`
+
+以下考点漏掉 `--facet` 会报错或数据被并入 `default`（详见
+[`tutor/topic-map.md`](./topic-map.md#1-聚合考点record---facet-必填)）：
+
+| Topic | Facets |
+|---|---|
+| `K05.TEST_CMMI_PATTERNS` | `testing` / `cmmi` / `design_patterns` |
+| `K06.DESIGN_DATA_VIEWS` | `high_level_design` / `data_design` / `uml_views` |
+| `K12.PATTERNS_SOA_MICROSERVICES` | `design_patterns` / `soa` / `microservices` |
+| `K13.VIEWS_SOA_LAYERING` | `four_plus_one` / `soa` / `layering` |
+
+上表由 [`scripts/gen_topic_map.py`](../scripts/gen_topic_map.py) 从
+`curriculum.json` 生成。**发现出入以 topic-map.md 为准。**
+
+### 证据分级（详见 PROGRESS_PROTOCOL §4）
+
+| 场景 | record？ | skill | mode | 能升 pass_ready？ |
+|---|---|---|---|---|
+| 客观题、闭卷、答对、`sure` | ✅ | recognition | diagnostic/practice | 是（累积 6 条证据 + 跨日 2 次） |
+| 答对但 `guessed` | ✅ | recognition | diagnostic | 否，只算 fragile |
+| 答错 | ✅ | recognition | diagnostic | 否，进 1/3/7/14 复习队列 |
+| 案例独立作答 + 逐项估分 | ✅ | application | practice/mock | 需 2 次 15/25 等价分 |
+| 案例只看讲解未作答 | ⚠️ 只写 note | application | practice | 否 |
+| 论文口述骨架 | ✅ | application | practice | 否 |
+| 论文限时成文 ≥ 2500 字 + 估分 | ✅ | production | mock | 需 2 篇达安全线 |
+| 学员纯聊天没作答 | ❌ | — | — | — |
+
+record 完再跑 `python3 scripts/tutor.py status` 确认落盘。
+
+## Step 5 · 反馈与换科
+
+对每道错题给三件套（口头即可，不再走 AskUserQuestion 免得打断节奏）：
+
+1. **错因分类**：
+   - `recall_failure`：概念记得但顺序/名字想不起来
+   - `concept_confusion`：混淆了两个相邻概念（例：CMM 老版 vs CMMI）
+   - `careless_reading`：题干"错误的是/不属于"读反
+   - `knowledge_gap`：完全没学过
+   - `application_error`：知识点会但套错场景（案例常见）
+
+2. **最小记忆钩子**：一句口诀 / 一张对比表 / 一个反例。
+   例：
+   > RUP 四阶段：**"初精构移"**——初定边界、精立架构（含风险消除）、构建功能、移交用户
+   > CMMI：**初·管·定·量·优**（L2 现在叫 Managed，老 CMM 才叫 Repeatable）
+
+3. **一道变式题**（口头答）
+
+反馈完再走 `recommend` 换下一考点；连续答对 2 组后主动提"换科"。
+
+## Boundaries
+
+- ❌ 用户未作答，不写任何 `record`
+- ❌ 蒙对不记 pass_ready，只算 fragile / learning
+- ❌ 单科 11 题小测不外推 75 分制成绩——限时整卷模考才是硬证据
+- ❌ 案例/论文的作答用 `--skill application` 或 `production`，不用 `recognition`
+- ❌ 案例只看讲解未作答：不算掌握证据
+- ❌ 作答前不展示 cheatsheet、参考答案、加粗正解
+- ❌ 不主动展示 `.study/` 的原始 JSON（除非用户明确问）
+
+## Troubleshooting
+
+| 症状 | 原因 | 处理 |
+|---|---|---|
+| `record` 报 `--facet is required` | 聚合考点漏 facet | 查 [`topic-map.md`](./topic-map.md) 补 facet |
+| topic-map 与 curriculum 不一致 | 有人改了 curriculum 没重跑生成脚本 | `python3 scripts/gen_topic_map.py` |
+| 学员答案里选项字母对不上 | label 用了字母以外内容 | 回 Step 3 校验 label 只放 A/B/C/D |
+| status 仍显示 `unmeasured` | 单题小测不能升 measured | 限时 65 题整卷模考才升级 |
+| 学员嫌打字慢改点选 | 走过一次就立刻切 AskUserQuestion | 后续每屏都点选，不要回退 |
+| 学员直接要答案 | PROGRESS_PROTOCOL 禁止直接给答案 | 走 scaffolding：给方法 + 让 TA 填空 |
+
+## Verification（每轮循环收尾自检）
+
+答完一组、准备下一组前，快速过一遍：
+
+- [ ] 每题都 `record` 了，`status` 里 attempt 数增加
+- [ ] 聚合考点每条都带了 `--facet`
+- [ ] 蒙对/不确定的题 `--confidence` 标了 `unsure` / `guessed`
+- [ ] 错题给了错因 + 记忆钩子 + 变式题
+- [ ] 没把 `✅` / `**答案**` / `**解析**` 泄给学员
+- [ ] 没有硬贴 exam-bank 原文（一律走 `sanitize_bank.py`）
+
+全部打勾才进入下一轮 `recommend`。
+
+## 相关工具
+
+| 工具 | 位置 | 作用 |
+|---|---|---|
+| CLI | [`scripts/tutor.py`](../scripts/tutor.py) | init / status / recommend / record / doctor |
+| 脱敏器 | [`scripts/sanitize_bank.py`](../scripts/sanitize_bank.py) | 剥 exam-bank 答案，输出结构化 JSON |
+| 考点表生成 | [`scripts/gen_topic_map.py`](../scripts/gen_topic_map.py) | 由 `curriculum.json` 生成 `topic-map.md` |
+| 教师人格 | [`.claude/agents/senior-architect-pass-coach.md`](../.claude/agents/senior-architect-pass-coach.md) | 覆盖诊断 / 案例 / 论文全流程决策 |
+| 记档协议 | [`PROGRESS_PROTOCOL.md`](./PROGRESS_PROTOCOL.md) | 证据分级、掌握度定义、私隐边界 |
+| 考点表 | [`topic-map.md`](./topic-map.md) | 自动生成，切勿手改 |

--- a/tutor/topic-map.md
+++ b/tutor/topic-map.md
@@ -1,0 +1,85 @@
+# Topic Map（由脚本生成，请勿手改）
+
+> 由 `python3 scripts/gen_topic_map.py` 从 [`tutor/curriculum.json`](./curriculum.json) 生成。若要修改，请改 curriculum.json 后重跑该脚本。
+
+## 1. 聚合考点（`record --facet` 必填）
+
+| Topic ID | 名称 | Facets |
+|---|---|---|
+| `K05.TEST_CMMI_PATTERNS` | 软件测试、CMMI 与常见设计模式 | `testing` / `cmmi` / `design_patterns` |
+| `K06.DESIGN_DATA_VIEWS` | 概要设计、数据设计与 UML 视图 | `high_level_design` / `data_design` / `uml_views` |
+| `K12.PATTERNS_SOA_MICROSERVICES` | 设计模式、SOA 与微服务核心概念 | `design_patterns` / `soa` / `microservices` |
+| `K13.VIEWS_SOA_LAYERING` | 4+1 视图、SOA 与分层架构 | `four_plus_one` / `soa` / `layering` |
+
+## 2. 所有考点 → 资源映射
+
+| Topic ID | 名称 | 科目 | 频次 | 时长(分钟) | 有 exam-bank 题 | 主要资源 |
+|---|---|---|---|---|---|---|
+| `K01.OS_MEMORY_KERNEL` | 操作系统内核、进程与存储管理 | comprehensive | 15 | 120 | ✅ | `exam-bank/02-os-concepts.md`, `cheatsheets/os-concepts.md`, `past-papers/HIGH_FREQ.md` |
+| `K02.NETWORK_PROTOCOLS` | 计算机网络与常用协议 | comprehensive/case | 15 | 90 | ✅ | `exam-bank/04-networking.md`, `knowledge-index/04-networking.md`, `notes/19-networking/README.md` |
+| `K03.SOFTWARE_DESIGN_UML` | 软件设计、内聚耦合与 UML 建模 | comprehensive/case/essay | 14 | 150 | ✅ | `exam-bank/05-uml.md`, `knowledge-index/05-uml.md`, `past-papers/case-types/04-uml-modeling.md` |
+| `K04.ARCH_STYLES_ABSD` | 架构风格、ABSD 与选型 | comprehensive/case/essay | 14 | 120 | ✅ | `exam-bank/10-architecture-styles.md`, `knowledge-index/10-architecture-styles.md`, `past-papers/case-types/03-style-comparison.md` (+1) |
+| `K05.TEST_CMMI_PATTERNS` | 软件测试、CMMI 与常见设计模式 | comprehensive/essay | 14 | 120 | ✅ | `exam-bank/07-software-engineering.md`, `exam-bank/13-design-patterns.md`, `cheatsheets/software-engineering-cmmi.md` |
+| `K06.DESIGN_DATA_VIEWS` | 概要设计、数据设计与 UML 视图 | comprehensive/case/essay | 12 | 120 | ✅ | `exam-bank/14-absd-views.md`, `knowledge-index/14-absd-views.md`, `cheatsheets/absd-and-adl.md` |
+| `K07.REALTIME_EMBEDDED` | 实时系统、嵌入式与调度基础 | comprehensive/case | 11 | 150 | ✅ | `exam-bank/22-embedded.md`, `knowledge-index/22-embedded.md`, `past-papers/case-types/08-embedded-components.md` |
+| `K08.SOFTWARE_PROCESS_MODELS` | 软件过程模型、敏捷与 RUP | comprehensive | 11 | 60 | ✅ | `exam-bank/07-software-engineering.md`, `notes/04-software-engineering/README.md`, `cheatsheets/software-engineering-cmmi.md` |
+| `K09.QUALITY_SCENARIOS` | 质量属性六元组与质量战术 | comprehensive/case/essay | 11 | 90 | ✅ | `exam-bank/11-quality-attributes.md`, `knowledge-index/11-quality-attributes.md`, `cheatsheets/quality-attributes.md` (+1) |
+| `K10.DATABASE_MODELING` | 关系数据库、范式与关系代数 | comprehensive/case | 10 | 150 | ✅ | `exam-bank/03-database.md`, `knowledge-index/03-database.md`, `past-papers/case-types/02-database-design.md` |
+| `K11.COMPONENTS_4PLUS1` | 构件平台与 4+1 视图 | comprehensive/case/essay | 9 | 75 | ✅ | `exam-bank/14-absd-views.md`, `knowledge-index/14-absd-views.md`, `notes/06-system-architecture-design/README.md` |
+| `K12.PATTERNS_SOA_MICROSERVICES` | 设计模式、SOA 与微服务核心概念 | comprehensive/case/essay | 9 | 150 | ✅ | `exam-bank/13-design-patterns.md`, `exam-bank/15-microservice-cloud-native.md`, `knowledge-index/15-microservice-cloud-native.md` (+1) |
+| `K13.VIEWS_SOA_LAYERING` | 4+1 视图、SOA 与分层架构 | comprehensive/case/essay | 8 | 90 | ✅ | `exam-bank/14-absd-views.md`, `exam-bank/26-soa-evolution.md`, `notes/12-case-layered/README.md` (+1) |
+| `K14.OS_SCHEDULING_FILES` | 操作系统调度与文件系统计算 | comprehensive | 7 | 120 | ✅ | `exam-bank/02-os-concepts.md`, `cheatsheets/os-concepts.md` |
+| `K15.STRUCTURED_ANALYSIS_DFD` | 结构化分析与 DFD | comprehensive/case | 7 | 75 | ✅ | `exam-bank/07-software-engineering.md`, `past-papers/case-types/04-uml-modeling.md` |
+| `K16.REQUIREMENTS_MANAGEMENT` | 需求工程、基线与变更管理 | comprehensive/case | 7 | 60 | ✅ | `exam-bank/07-software-engineering.md`, `notes/04-software-engineering/README.md` |
+| `K17.IP_COPYRIGHT` | 知识产权、著作权与标准化 | comprehensive | 7 | 30 | ✅ | `exam-bank/06-ip-and-standards.md`, `knowledge-index/06-ip-and-standards.md`, `cheatsheets/ip-and-standards.md` |
+| `K18.COMPUTER_ARCH_STORAGE` | 计算机组成与存储层次 | comprehensive | 6 | 90 | ✅ | `exam-bank/01-computer-systems.md`, `knowledge-index/01-computer-systems.md`, `cheatsheets/computer-systems-formulas.md` |
+| `K19.ATAM_TACTICS` | ATAM、四类点与质量属性战术 | comprehensive/case/essay | 6 | 90 | ✅ | `exam-bank/12-atam-evaluation.md`, `knowledge-index/12-atam-evaluation.md`, `cheatsheets/architecture-evaluation.md` (+1) |
+| `K20.SECURITY_FOUNDATIONS` | CIA、安全服务、STRIDE 与等保 | comprehensive/case/essay | 6 | 120 | ✅ | `exam-bank/21-security.md`, `knowledge-index/21-security.md`, `past-papers/case-types/07-security-architecture.md` (+1) |
+| `K21.MESSAGING_CACHE` | 消息中间件、缓存与一致性 | comprehensive/case/essay | 5 | 120 | ✅ | `exam-bank/16-middleware.md`, `exam-bank/18-cache.md`, `knowledge-index/16-middleware.md` (+2) |
+| `K22.ENGLISH_READING` | 专业英语阅读与高频词 | comprehensive | 23 | 75 | ✅ | `exam-bank/23-english-reading.md`, `cheatsheets/english-reading.md`, `past-papers/HIGH_FREQ.md` |
+| `C01.CASE_ATAM` | 案例主赛道：架构评估与质量属性 | case | 0 | 120 | ⚠️ 无 | `past-papers/CASE_SURVIVAL.md`, `past-papers/case-types/01-architecture-evaluation.md` |
+| `C02.CASE_DATABASE` | 案例主赛道：数据库设计 | case | 0 | 180 | ⚠️ 无 | `past-papers/CASE_SURVIVAL.md`, `past-papers/case-types/02-database-design.md` |
+| `C03.CASE_MESSAGING_CACHE` | 案例主赛道：消息与缓存 | case | 0 | 150 | ⚠️ 无 | `past-papers/CASE_SURVIVAL.md`, `past-papers/case-types/06-messaging-caching.md` |
+| `C04.CASE_MICROSERVICE` | 案例主赛道：微服务拆分与治理 | case | 0 | 180 | ⚠️ 无 | `past-papers/CASE_SURVIVAL.md`, `past-papers/case-types/05-microservice-refactor.md` |
+| `P01.ESSAY_ARCHITECTURE` | 论文主题：软件架构设计 | essay | 10 | 300 | ⚠️ 无 | `past-papers/PAPER_SURVIVAL.md`, `past-papers/paper-topics/01-architecture-design.md`, `past-papers/paper-samples/01-architecture-design.md` |
+| `P02.ESSAY_BIG_DATA` | 论文主题：大数据与 NoSQL | essay | 10 | 300 | ⚠️ 无 | `past-papers/PAPER_SURVIVAL.md`, `past-papers/paper-topics/06-big-data-nosql.md`, `past-papers/paper-samples/06-big-data-nosql.md` |
+| `P03.ESSAY_RELIABILITY` | 论文主题：可靠性与高可用 | essay | 5 | 240 | ⚠️ 无 | `past-papers/PAPER_SURVIVAL.md`, `past-papers/paper-topics/03-reliability-design.md`, `past-papers/paper-samples/03-reliability-design.md` |
+| `P04.ESSAY_MICROSERVICE` | 论文主题：微服务与云原生 | essay | 5 | 240 | ⚠️ 无 | `past-papers/PAPER_SURVIVAL.md`, `past-papers/paper-topics/05-microservice-cloud-native.md`, `past-papers/paper-samples/05-microservice-cloud-native.md` |
+| `P05.ESSAY_EAI` | 论文主题：企业应用集成 EAI | essay | 5 | 240 | ⚠️ 无 | `past-papers/PAPER_SURVIVAL.md`, `past-papers/paper-topics/11-enterprise-integration.md`, `past-papers/paper-samples/11-enterprise-integration.md` |
+| `P06.ESSAY_ATAM` | 论文主题：架构评估 | essay | 3 | 210 | ⚠️ 无 | `past-papers/PAPER_SURVIVAL.md`, `past-papers/paper-topics/02-architecture-evaluation.md`, `past-papers/paper-samples/02-architecture-evaluation.md` |
+
+## 3. 无 exam-bank 题的考点（自编题时 `--source-type self_authored`）
+
+- `C01.CASE_ATAM` — 案例主赛道：架构评估与质量属性
+- `C02.CASE_DATABASE` — 案例主赛道：数据库设计
+- `C03.CASE_MESSAGING_CACHE` — 案例主赛道：消息与缓存
+- `C04.CASE_MICROSERVICE` — 案例主赛道：微服务拆分与治理
+- `P01.ESSAY_ARCHITECTURE` — 论文主题：软件架构设计
+- `P02.ESSAY_BIG_DATA` — 论文主题：大数据与 NoSQL
+- `P03.ESSAY_RELIABILITY` — 论文主题：可靠性与高可用
+- `P04.ESSAY_MICROSERVICE` — 论文主题：微服务与云原生
+- `P05.ESSAY_EAI` — 论文主题：企业应用集成 EAI
+- `P06.ESSAY_ATAM` — 论文主题：架构评估
+
+## 4. exam-bank 文件 → topic 反查
+
+- `exam-bank/01-computer-systems.md` → `K18.COMPUTER_ARCH_STORAGE`
+- `exam-bank/02-os-concepts.md` → `K01.OS_MEMORY_KERNEL`, `K14.OS_SCHEDULING_FILES`
+- `exam-bank/03-database.md` → `K10.DATABASE_MODELING`
+- `exam-bank/04-networking.md` → `K02.NETWORK_PROTOCOLS`
+- `exam-bank/05-uml.md` → `K03.SOFTWARE_DESIGN_UML`
+- `exam-bank/06-ip-and-standards.md` → `K17.IP_COPYRIGHT`
+- `exam-bank/07-software-engineering.md` → `K05.TEST_CMMI_PATTERNS`, `K08.SOFTWARE_PROCESS_MODELS`, `K15.STRUCTURED_ANALYSIS_DFD`, `K16.REQUIREMENTS_MANAGEMENT`
+- `exam-bank/10-architecture-styles.md` → `K04.ARCH_STYLES_ABSD`
+- `exam-bank/11-quality-attributes.md` → `K09.QUALITY_SCENARIOS`
+- `exam-bank/12-atam-evaluation.md` → `K19.ATAM_TACTICS`
+- `exam-bank/13-design-patterns.md` → `K05.TEST_CMMI_PATTERNS`, `K12.PATTERNS_SOA_MICROSERVICES`
+- `exam-bank/14-absd-views.md` → `K06.DESIGN_DATA_VIEWS`, `K11.COMPONENTS_4PLUS1`, `K13.VIEWS_SOA_LAYERING`
+- `exam-bank/15-microservice-cloud-native.md` → `K12.PATTERNS_SOA_MICROSERVICES`
+- `exam-bank/16-middleware.md` → `K21.MESSAGING_CACHE`
+- `exam-bank/18-cache.md` → `K21.MESSAGING_CACHE`
+- `exam-bank/21-security.md` → `K20.SECURITY_FOUNDATIONS`
+- `exam-bank/22-embedded.md` → `K07.REALTIME_EMBEDDED`
+- `exam-bank/23-english-reading.md` → `K22.ENGLISH_READING`
+- `exam-bank/26-soa-evolution.md` → `K13.VIEWS_SOA_LAYERING`
+


### PR DESCRIPTION
## Summary

把"出题→作答→判分→记档→反馈→换科"从各 Agent 会话内的临时约定沉淀为仓库内可复用的运行时管道，让 Codex / Claude Code / Qwen Code 等任一 Agent 在本仓库里都能按同一套 SOP 稳定执行。

背景来自最近几次私教会话反复踩到的两个坑：
- 直接引用 exam-bank 段落会把 ``✅`` / ``**答案**：X`` / ``**解析**：`` 一并泄露给学员，实质等于开卷
- 聚合考点（K05 / K06 / K12 / K13）record 时漏 ``--facet`` 会报错或让数据落到 ``default`` bucket
- topic ↔ 题库文件的对应关系我在会话里记错过（例如误以为 K15.STRUCTURED_ANALYSIS_DFD 无题；实际在 exam-bank/07 里有对应题）

## Changes

- **`tutor/quiz-loop-sop.md`（新增）**：6 步管道 + AskUserQuestion 出题姿势（label 只放 A/B/C/D）+ 证据分级速查 + Boundaries + Troubleshooting + 收尾自检清单
- **`tutor/topic-map.md`（新增，脚本生成）**：聚合考点 → facet 清单、所有考点 → 资源映射、无 exam-bank 题的考点清单（需 ``--source-type self_authored``）、exam-bank 文件反查表
- **`scripts/sanitize_bank.py`（新增）**：按 ``### N.`` 切块并剥除 ``✅`` / 加粗正解 / ``**答案**`` / ``**解析**``，输出结构化 JSON。``correct`` 与 ``explanation`` 仅供 coach 判分，不呈现给学员。
- **`scripts/gen_topic_map.py`（新增）**：从 ``tutor/curriculum.json`` 生成 ``topic-map.md``，支持 ``--check`` 用于 CI 防漂移
- **`tests/test_sanitize_bank.py`（新增）**：7 条 unittest 钉住脱敏契约——真实题库（07 号 1/4/6 题）+ 4 种格式变体（``✅`` 前缀、整行 ``- **B. ...**`` 加粗、显式 ``**答案**`` 优先于 marker、全角冒号）+ 2 条 CLI 行为（缺失题号告警、缺失文件退出码）
- **`AGENTS.md` / `.claude/agents/senior-architect-pass-coach.md` / `tutor/README.md`**：在既有指引里加入 SOP 与 topic map 的入口链接

## Test plan

- [x] ``python3 -m unittest discover -s tests -v`` — 43 passed（含 7 条新增）
- [x] ``python3 scripts/gen_topic_map.py --check`` — clean（可作为后续 CI 步骤）
- [x] ``python3 scripts/sanitize_bank.py exam-bank/07-software-engineering.md 1 4 6`` — 输出干净的 stem/options，``✅`` 与 ``**答案**`` 未泄漏
- [ ] Reviewer 手动跑一遍完整循环：``recommend`` → ``sanitize_bank`` → AskUserQuestion → ``record`` → ``status``，确认 status 有增量

## Notes for reviewer

- 未改动 ``scripts/tutor.py`` 与 ``tutor/curriculum.json``，避免混入无关变更
- ``tutor/topic-map.md`` 是生成产物，建议后续如果引入 CI，加一条 ``python3 scripts/gen_topic_map.py --check`` 作为 lint
- 工作区里的 ``scripts/build_high_frequency_mock_pdf.py`` 是本地未跟踪文件，与本 PR 无关，未纳入