### PR TITLE
fix(mind-maps): quadrantChart 边界值 1.0 导致 GitHub 渲染 Lexical error (#7)

### DIFF
--- a/mind-maps/00-overall.md
+++ b/mind-maps/00-overall.md
@@ -68,6 +68,13 @@ mindmap
 
 ## 备考优先级矩阵
 
+<!--
+  维护提示：quadrantChart 的坐标严格保持在 (0, 1) 开区间。
+  GitHub 当前的 Mermaid 渲染器在遇到边界值 1.0 时会抛
+  `Lexical error ... Unrecognized text`（见 issue #7 截图），
+  修改数据点时请勿把任一分量写成 0 或 1，最靠边取 0.02 / 0.98。
+-->
+
 ```mermaid
 quadrantChart
     title 考点优先级矩阵
@@ -86,5 +93,5 @@ quadrantChart
     "区块链": [0.7, 0.5]
     "嵌入式": [0.8, 0.4]
     "软件可靠性": [0.5, 0.75]
-    "论文写作": [0.8, 1.0]
+    "论文写作": [0.8, 0.98]
 ```


### PR DESCRIPTION
Closes #7

## 问题

`mind-maps/00-overall.md` 的备考优先级矩阵在 GitHub 上渲染失败，红框报错：

```
Unable to render rich display
Lexical error on line 18. Unrecognized text.
... "论文写作": [0.8, 1.0]
```

## 根因

Mermaid 的 `quadrantChart` 数据点在 GitHub 当前的渲染器版本下无法接受坐标端点 `1.0`，即使官方文档写的范围是 `[0, 1]` 闭区间。`ab4717b` 的上一次修复只处理了 `quadrant-N` 标签加引号，漏掉了这条 y=1.0 的数据点。

## 修复

- `"论文写作"` 的 y 分量 `1.0` → `0.98`，视觉上仍在右上角最高频区域，四象限归属不变
- 在 `quadrantChart` 前加维护注释，明确坐标必须严格在开区间 `(0, 1)`，`0` 和 `1` 都会触发 lexer bug；防止后续新增数据点再踩同一坑

## 验证

- 全仓库 `grep -rn "quadrantChart"` 只此一处
- 全仓库 `grep -rn "\[[01]\.0"` 在 mind-maps/ 下无其他边界值
- 本地 Markdown Preview 渲染正常；合并后请在 GitHub PR/Files 页面确认预览
- 未改动任何脚本或代码，`tests/` 不受影响